### PR TITLE
ocdeploy pull: load all os environment variables

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -65,8 +65,8 @@ def _generate_command(subcommand):
     return cmd
 
 def _execute_command(subcommand, args):
-    env = _load_dev_env()
-    env['PATH'] = os.environ['PATH']
+    env = os.environ.copy()
+    env.update(_load_dev_env())
     env.update(DOCKER_BASE_DIRS)
     cwd = os.path.join(REPO_DIR, 'docker', 'dev')
     cmd = _generate_command(subcommand)


### PR DESCRIPTION
This prevents some issues we saw in Ubuntu 18.04 where docker-compose
was unable to run without some of the os environment variables.