### PR TITLE
Fix 'notebooks' girder setting typo

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -158,7 +158,7 @@
   with_items:
     - {
       "key": "app.features.notebooks",
-      "value": "{{ app_feature_notesbooks | default(true) }}"
+      "value": "{{ app_feature_notebooks | default(true) }}"
     }
 
 - include: newt-auth.yml


### PR DESCRIPTION
Signed-off-by: Patrick Avery <patrick.avery@kitware.com>