### PR TITLE
Updates for the girder 3 changes in past month

### DIFF
--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -45,23 +45,6 @@
         - login: cumulus
           type: member
 
-- name: restart girder
-  girder:
-    host: "{{girder_host}}"
-    port: "{{girder_port}}"
-    scheme: "{{girder_scheme}}"
-    apiRoot: "{{girder_api_root}}"
-    username: "mongochem"
-    password: "{{ mongochem_password }}"
-    put:
-      path: "system/restart"
-
-- name: Wait until server restarts
-  wait_for:
-    host="{{girder_host}}"
-    port="{{girder_port}}"
-    delay=5
-
 - name: Create filesystem assetstore
   girder:
     host: "{{girder_host}}"

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -45,36 +45,6 @@
         - login: cumulus
           type: member
 
-- name: Enable cumulus plugins
-  girder:
-    host: "{{girder_host}}"
-    port: "{{girder_port}}"
-    scheme: "{{girder_scheme}}"
-    apiRoot: "{{girder_api_root}}"
-    username: "mongochem"
-    password: "{{ mongochem_password }}"
-    plugins:
-      - cumulus_plugin
-      - sftp
-      - newt
-      - taskflow
-    state: present
-
-- name: Enable OC plugins
-  girder:
-    host: "{{girder_host}}"
-    port: "{{girder_port}}"
-    scheme: "{{girder_scheme}}"
-    apiRoot: "{{girder_api_root}}"
-    username: "mongochem"
-    password: "{{ mongochem_password }}"
-    plugins:
-      - molecules
-      - notebooks
-      - queues
-      - app
-    state: present
-
 - name: restart girder
   girder:
     host: "{{girder_host}}"


### PR DESCRIPTION
Here is a summary of the commits:

Remove enabling of girder plugins in ansible
==================================

In girder 3, plugins are enabled by pip installing them,
and they are disabled by pip uninstalling them.

Because plugins cannot be enabled using other methods,
enabling of girder plugins in ansible was removed as of [this commit](https://github.com/girder/girder/commit/fdef621b184600d9b3edf1634ccd9f618dea9fcf).
Thus, remove the enabling of girder plugins in ansible to reflect that.

Remove the restarting of girder in ansible
===============================

In girder 3, the ability to restart girder via http
was removed in [this commit](https://github.com/girder/girder/commit/0c85fac11786f4b2283936bc783f7feee85e05dc).

As such, girder can no longer be restarted in ansible. So
remove it. It is probably not really needed anymore anyways,
since plugins can no longer be enabled/disabled in ansible.