### PR TITLE
Mount plugin subdirectories for dev mounting

### DIFF
--- a/docker/dev/docker-compose.cumulus.yml
+++ b/docker/dev/docker-compose.cumulus.yml
@@ -2,7 +2,7 @@ version: "2.0"
 services:
   girder:
     volumes:
-      - $CUMULUS/girder/cumulus:/cumulus/girder/cumulus
-      - $CUMULUS/girder/taskflow:/cumulus/girder/taskflow
-      - $CUMULUS/girder/sftp:/cumulus/girder/sftp
-      - $CUMULUS/girder/newt:/cumulus/girder/newt
+      - $CUMULUS/girder/cumulus/cumulus_plugin:/cumulus/girder/cumulus/cumulus_plugin
+      - $CUMULUS/girder/taskflow/taskflow:/cumulus/girder/taskflow/taskflow
+      - $CUMULUS/girder/sftp/sftp:/cumulus/girder/sftp/sftp
+      - $CUMULUS/girder/newt/newt:/cumulus/girder/newt/newt

--- a/docker/dev/docker-compose.mongochemserver.yml
+++ b/docker/dev/docker-compose.mongochemserver.yml
@@ -2,7 +2,7 @@ version: "2.0"
 services:
   girder:
     volumes:
-      - $MONGOCHEMSERVER/girder/app:/mongochemserver/girder/app
-      - $MONGOCHEMSERVER/girder/notebooks:/mongochemserver/girder/notebooks
-      - $MONGOCHEMSERVER/girder/molecules:/mongochemserver/girder/molecules
-      - $MONGOCHEMSERVER/girder/queues:/mongochemserver/girder/queues
+      - $MONGOCHEMSERVER/girder/app/app:/mongochemserver/girder/app/app
+      - $MONGOCHEMSERVER/girder/notebooks/notebooks:/mongochemserver/girder/notebooks/notebooks
+      - $MONGOCHEMSERVER/girder/molecules/molecules:/mongochemserver/girder/molecules/molecules
+      - $MONGOCHEMSERVER/girder/queues/queues:/mongochemserver/girder/queues/queues


### PR DESCRIPTION
The plugins do not appear to load correctly when mounting
the top-level plugin directory, possibly because the
egg info is overwritten.

Mounting the plugin subdirectory appears to work properly.
Thus, mount the plugin subdirectory instead.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>