### PR TITLE
Keep the client code and the nginx container separate

### DIFF
--- a/docker/dev/docker-compose.mongochemclient.yml
+++ b/docker/dev/docker-compose.mongochemclient.yml
@@ -1,6 +1,6 @@
 version: "2.0"
 services:
-  nginx-dev:
+  client:
     volumes:
       - $MONGOCHEMCLIENT/build:/usr/share/nginx/html
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     depends_on:
       - 'girder'
       - 'hub'
+      - 'client'
+
+
+  client:
+    image: openchemistry/mongochemclient:latest
 
   ansible:
     image: openchemistry/ansible

--- a/docker/dev/nginx/Dockerfile
+++ b/docker/dev/nginx/Dockerfile
@@ -1,15 +1,4 @@
-FROM node:10 AS build
-
-RUN apt-get update && apt-get -y install \
-  git
-
-RUN git clone https://github.com/OpenChemistry/mongochemclient && \
-  cd mongochemclient && \
-  npm install && \
-  REACT_APP_DEPLOYMENT=development npm run build
-
 FROM nginx
-COPY --from=build /mongochemclient/build /usr/share/nginx/html
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx/nginx.girder.conf /etc/nginx/conf.d/girder.conf
 COPY wait-for-it.sh /wait-for-it.sh

--- a/docker/dev/nginx/nginx.girder.conf
+++ b/docker/dev/nginx/nginx.girder.conf
@@ -11,6 +11,10 @@ upstream girder_server {
     server girder:8080 max_fails=10 fail_timeout=30;
 }
 
+upstream client {
+    server client max_fails=10 fail_timeout=30;
+}
+
 
 
 server {
@@ -61,7 +65,7 @@ server {
     }
 
     location / {
-        try_files $uri $uri/ /index.html;
+        proxy_pass http://client;
     }
 
     client_max_body_size 500M;


### PR DESCRIPTION
Add openchemistry/mongochemclient to the docker compose config,
and have the nginx container proxy requests to it.

Previously the mongochemclient code would get baked into the nginx
image.

Fixes https://github.com/OpenChemistry/oc-web-components/issues/121