### PR TITLE
Run girder in --dev mode with ocdeploy

### DIFF
--- a/dev/dev.env
+++ b/dev/dev.env
@@ -4,3 +4,4 @@
 #OPENCHEMISTRYPY=/home/cjh/work/source/openchemistrypy
 #JUPTERLAB_CJSON=/home/cjh/work/source/jupyterlab_cjson
 #JUPTERLAB_APP_DIR=/home/cjh/virtualenv/jjlab/share/jupyter/lab
+GIRDER_EXTRA_ARGS=--dev

--- a/docker/girder/docker-compose.yml
+++ b/docker/girder/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   girder:
     image: openchemistry/mongochemserver:latest
-    command: -d ${MONGODB_URL}
+    command: -d ${MONGODB_URL} ${GIRDER_EXTRA_ARGS}
     volumes:
      - assetstore:/assetstore
      - keys:/keys


### PR DESCRIPTION
Utilize the new --dev option for girder so that it can be ran in
development mode. This is useful because in development mode, girder
will automatically restart if changes to the plugins are made.

If the GIRDER_EXTRA_ARGS environment variable is not set or empty, then
girder is ran in production mode.