### PR TITLE
Added basic Open Babel flask container

### DIFF
--- a/docker/openbabel/Dockerfile
+++ b/docker/openbabel/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+RUN apt-get update -y
+RUN apt-get install -y \
+  build-essential \
+  pkg-config \
+  libopenbabel-dev \
+  swig
+
+COPY requirements.txt /app/
+RUN pip3 install -r /app/requirements.txt
+
+COPY src/* /app/
+
+WORKDIR /app
+
+ENTRYPOINT ["python3", "main.py"]

--- a/docker/openbabel/docker-compose.yml
+++ b/docker/openbabel/docker-compose.yml
@@ -1,0 +1,4 @@
+openbabel:
+  image: openchemistry/openbabel:latest
+  ports:
+   - "5000:5000"

--- a/docker/openbabel/requirements.txt
+++ b/docker/openbabel/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openbabel==2.4.1

--- a/docker/openbabel/src/main.py
+++ b/docker/openbabel/src/main.py
@@ -14,14 +14,14 @@ def convert(output_format):
 
     The output format is specified in the path. The input format and
     the data are specified in the body (in json format) as the keys
-    "input_format" and "data", respectively.
+    "format" and "data", respectively.
 
     Some options may also be specified in the json body. The following
     options will be used in all cases other than the special ones:
 
         gen3d (bool): should we generate 3d coordinates?
-        add_hydrogens (bool): should we add hydrogens?
-        out_options (dict): what extra output options are there?
+        addHydrogens (bool): should we add hydrogens?
+        outOptions (dict): what extra output options are there?
 
     Special cases are:
         output_format:
@@ -32,10 +32,10 @@ def convert(output_format):
     Curl example:
     curl -X POST 'http://localhost:5000/convert/inchi' \
       -H "Content-Type: application/json" \
-      -d '{"input_format": "smiles", "data": "CCO"}'
+      -d '{"format": "smiles", "data": "CCO"}'
     """
     json_data = request.get_json()
-    input_format = json_data['input_format']
+    input_format = json_data['format']
     data = json_data['data']
 
     # Treat special cases with special functions
@@ -54,8 +54,8 @@ def convert(output_format):
 
     # Check for a few specific arguments
     gen3d = json_data.get('gen3d', False)
-    add_hydrogens = json_data.get('add_hydrogens', False)
-    out_options = json_data.get('out_options', {})
+    add_hydrogens = json_data.get('addHydrogens', False)
+    out_options = json_data.get('outOptions', {})
 
     return openbabel.convert_str(data, input_format, output_format,
                                  gen3d=gen3d, add_hydrogens=add_hydrogens,

--- a/docker/openbabel/src/main.py
+++ b/docker/openbabel/src/main.py
@@ -1,0 +1,66 @@
+import json
+
+from flask import Flask
+from flask import request
+
+import openbabel_api as openbabel
+
+app = Flask(__name__)
+
+
+@app.route('/convert/<output_format>', methods=['POST'])
+def convert(output_format):
+    """Convert molecule data from one format to another via OpenBabel
+
+    The output format is specified in the path. The input format and
+    the data are specified in the body (in json format) as the keys
+    "input_format" and "data", respectively.
+
+    Some options may also be specified in the json body. The following
+    options will be used in all cases other than the special ones:
+
+        gen3d (bool): should we generate 3d coordinates?
+        add_hydrogens (bool): should we add hydrogens?
+        out_options (dict): what extra output options are there?
+
+    Special cases are:
+        output_format:
+            svg: returns the SVG
+            smi: returns canonical smiles
+            inchi: returns json containing "inchi" and "inchikey"
+
+    Curl example:
+    curl -X POST 'http://localhost:5000/convert/inchi' \
+      -H "Content-Type: application/json" \
+      -d '{"input_format": "smiles", "data": "CCO"}'
+    """
+    json_data = request.get_json()
+    input_format = json_data['input_format']
+    data = json_data['data']
+
+    # Treat special cases with special functions
+    out_lower = output_format.lower()
+    if out_lower == 'svg':
+        return openbabel.to_svg(data, input_format)
+    elif out_lower in ['smiles', 'smi']:
+        return openbabel.to_smiles(data, input_format)
+    elif out_lower == 'inchi':
+        inchi, inchikey = openbabel.to_inchi(data, input_format)
+        d = {
+            'inchi': inchi,
+            'inchikey': inchikey
+        }
+        return json.dumps(d)
+
+    # Check for a few specific arguments
+    gen3d = json_data.get('gen3d', False)
+    add_hydrogens = json_data.get('add_hydrogens', False)
+    out_options = json_data.get('out_options', {})
+
+    return openbabel.convert_str(data, input_format, output_format,
+                                 gen3d=gen3d, add_hydrogens=add_hydrogens,
+                                 out_options=out_options)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')

--- a/docker/openbabel/src/openbabel_api.py
+++ b/docker/openbabel/src/openbabel_api.py
@@ -1,0 +1,110 @@
+from openbabel import OBMol, OBConversion
+
+import pybel
+
+import re
+
+inchi_validator = re.compile('InChI=[0-9]S?\\/')
+
+
+# This function only validates the first part. It does not guarantee
+# that the entire InChI is valid.
+def validate_start_of_inchi(inchi):
+    if not inchi_validator.match(inchi):
+        raise Exception('Invalid InChI: "' + inchi + '"')
+
+
+# gen3d should be true for 2D input formats such as inchi or smiles
+def convert_str(str_data, in_format, out_format, gen3d=False,
+                add_hydrogens=False, out_options=None):
+
+    # Make sure that the start of InChI is valid before passing it to
+    # Open Babel, or Open Babel will crash the server.
+    if in_format.lower() == 'inchi':
+        validate_start_of_inchi(str_data)
+
+    if out_options is None:
+        out_options = {}
+
+    obMol = OBMol()
+    conv = OBConversion()
+    conv.SetInFormat(in_format)
+    conv.SetOutFormat(out_format)
+    conv.ReadString(obMol, str_data)
+
+    if add_hydrogens:
+        obMol.AddHydrogens()
+
+    if gen3d:
+        # Generate 3D coordinates for the input
+        mol = pybel.Molecule(obMol)
+        mol.make3D()
+
+    for option, value in out_options.items():
+        conv.AddOption(option, conv.OUTOPTIONS, value)
+
+    return (conv.WriteString(obMol), conv.GetOutFormat().GetMIMEType())
+
+
+def to_inchi(str_data, in_format):
+    mol = OBMol()
+    conv = OBConversion()
+    conv.SetInFormat(in_format)
+    # Hackish for now, convert to xyz first...
+    conv.SetOutFormat('xyz')
+    conv.ReadString(mol, str_data)
+    xyz = conv.WriteString(mol)
+
+    # Now convert to inchi and inchikey.
+    mol = OBMol()
+    conv.SetInFormat('xyz')
+    conv.ReadString(mol, xyz)
+
+    conv.SetOutFormat('inchi')
+    inchi = conv.WriteString(mol).rstrip()
+    conv.SetOptions("K", conv.OUTOPTIONS)
+    inchikey = conv.WriteString(mol).rstrip()
+
+    return (inchi, inchikey)
+
+
+def to_smiles(str_data, in_format):
+    # The smiles has returns at the end of it, and may contain
+    # a return in the middle with a common name. Get rid of
+    # all of these.
+    # Use canonical smiles
+    smiles, mime = convert_str(str_data, in_format, 'can')
+    smiles = smiles.strip().split[0]
+    return (smiles, mime)
+
+
+def atom_count(str_data, in_format):
+    mol = OBMol()
+    conv = OBConversion()
+    conv.SetInFormat(in_format)
+    conv.ReadString(mol, str_data)
+
+    return mol.NumAtoms()
+
+
+def get_formula(str_data, in_format):
+    # Inchi must start with 'InChI='
+    if in_format == 'inchi' and not str_data.startswith('InChI='):
+        str_data = 'InChI=' + str_data
+        validate_start_of_inchi(str_data)
+    # Get the molecule using the "Hill Order" - i. e., C first, then H,
+    # and then alphabetical.
+    mol = OBMol()
+    conv = OBConversion()
+    conv.SetInFormat(in_format)
+    conv.ReadString(mol, str_data)
+
+    return mol.GetFormula()
+
+
+def to_svg(str_data, in_format):
+    out_options = {
+        'b': 'none',  # transparent background color
+        'B': 'black'  # black bonds color
+    }
+    return convert_str(str_data, in_format, 'svg', out_options=out_options)


### PR DESCRIPTION
It can currently only convert formats, but more endpoints and
functions can be added in the future. The "openbabel_api.py"
file was modified from the file [here](https://github.com/OpenChemistry/mongochemserver/blob/master/girder/molecules/molecules/openbabel.py).

Documentation for the convert function can be seen in the main.py
file.

An example of using it to convert smiles to xyz and generate 3D
coordinates is as follows:
```
> curl -X POST 'http://localhost:5000/convert/xyz' -H "Content-Type: application/json" -d '{"format": "smiles", "data": "CCO", "gen3d": true}'

9

C          1.07579        0.04200       -0.05942
C          2.59038        0.03826       -0.05539
O          3.07166       -1.22565        0.37800
H          0.68946        1.00611       -0.40166
H          0.68523       -0.15819        0.94373
H          0.69041       -0.74634       -0.71434
H          2.98292        0.81128        0.61217
H          2.97618        0.22333       -1.06208
H          2.73371       -1.37537        1.27738
```