### PR TITLE
Use Open Babel flask docker image

### DIFF
--- a/ansible/dev.yml
+++ b/ansible/dev.yml
@@ -12,3 +12,10 @@
   connection: local
   roles:
     - role: jena
+
+- hosts: openbabel
+  vars:
+    ansible_python_interpreter: "/usr/local/bin/python"
+  connection: local
+  roles:
+    - role: openbabel

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -10,3 +10,4 @@ jena_admin_user: admin
 jena_admin_password: letmein
 jena_url: http://jena-fuseki:3030
 jena_dataset: openchemistry
+openbabel_url: http://localhost:4040

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -10,4 +10,4 @@ jena_admin_user: admin
 jena_admin_password: letmein
 jena_url: http://jena-fuseki:3030
 jena_dataset: openchemistry
-openbabel_url: http://localhost:4040
+openbabel_url: http://openbabel:5000

--- a/ansible/inventory/localhost
+++ b/ansible/inventory/localhost
@@ -3,3 +3,6 @@ localhost
 
 [jena]
 localhost
+
+[openbabel]
+localhost

--- a/ansible/roles/openbabel/tasks/main.yml
+++ b/ansible/roles/openbabel/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Configure Open Babel settings
+  girder:
+    host: "{{girder_host}}"
+    port: "{{girder_port}}"
+    scheme: "{{girder_scheme}}"
+    username: "mongochem"
+    password: "{{ mongochem_password }}"
+    setting:
+      key: "{{item.key}}"
+      value: "{{item.value}}"
+    state: present
+  with_items:
+    - {
+      "key": "molecules.openbabel.url",
+      "value": "{{ openbabel_url | default('http://openbabel:5000') }}"
+    }

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -155,3 +155,8 @@
       delegate_to: "{{ 'localhost' if delegate_local_jena is defined else omit }}"
   tags: jena
 
+- hosts: openbabel
+  roles:
+    - role: openbabel
+      delegate_to: localhost
+  tags: openbabel

--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,8 @@ DOCKER_BASE_DIRS = {
     'JUPYTERHUB_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'jupyterhub'),
     'DEV_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'dev'),
     'GIRDER_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'girder'),
-    'JENA_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'jena')
+    'JENA_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'jena'),
+    'OPENBABEL_DOCKER_DIR': os.path.join(REPO_DIR, 'docker', 'openbabel')
 }
 
 def _load_dev_env():
@@ -36,7 +37,8 @@ BASE_COMPOSE_FILES = [
     'docker-compose.yml',
     '../girder/docker-compose.yml',
     '../jupyterhub/docker-compose.yml',
-    '../jena/docker-compose.yml'
+    '../jena/docker-compose.yml',
+    '../openbabel/docker-compose.yml'
 ]
 
 def _override_files(vars):

--- a/docker/nersc/docker-compose.yml
+++ b/docker/nersc/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     depends_on:
       - db-mongodb
     environment:
-      - GIRDER_PORT=8080 
+      - GIRDER_PORT=8080
 
   app-rabbitmq:
     image: rabbitmq
@@ -51,7 +51,7 @@ services:
       - DAC_OVERRIDE
       - SETUID
       - SETGID
-      - NET_BIND_SERVICE 
+      - NET_BIND_SERVICE
 
   app-celery-command:
     image: openchemistry/celery_worker:latest
@@ -78,7 +78,7 @@ services:
     environment:
      - GIRDER_PORT=8080
      - OC_ACCOUNT=m2485
-      
+
 
   app-celery-monitor:
     image: openchemistry/celery_worker:latest
@@ -104,7 +104,7 @@ services:
      - app-keys.oc:/keys
     environment:
      - GIRDER_PORT=8080
-  
+
   app-mongochemclient:
     image: openchemistry/mongochemclient:latest
     labels:
@@ -149,6 +149,20 @@ services:
     depends_on:
       - app-girder
       - app-mongochemclient
+
+  app-openbabel:
+    image: openchemistry/openbabel:latest
+    labels:
+      io.rancher.container.pull_image: always
+    retain_ip: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
 
 volumes:
   app-assetstore.oc:

--- a/docker/openbabel/docker-compose.yml
+++ b/docker/openbabel/docker-compose.yml
@@ -2,5 +2,3 @@ version: '2'
 services:
   openbabel:
     image: openchemistry/openbabel:latest
-    ports:
-      - 4040:4040

--- a/docker/openbabel/docker-compose.yml
+++ b/docker/openbabel/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  openbabel:
+    image: openchemistry/openbabel:latest
+    ports:
+      - 4040:4040


### PR DESCRIPTION
In mongochemserver, as of [this PR](https://github.com/OpenChemistry/mongochemserver/pull/144),
Open Babel is no longer used through direct API calls. Instead,
it is called as an Open Babel flask docker image.

This PR gets mongochemdeploy to add Open Babel to docker-compose,
and the config is set up so that it can be called by mongochemserver.