### PR TITLE
Fix the torchani docker build and lock in versions

### DIFF
--- a/docker/torchani/Dockerfile
+++ b/docker/torchani/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.7
 
 COPY requirements.txt /app/
 RUN pip install -r /app/requirements.txt
-RUN pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html
-RUN pip install torchani
+RUN pip install torch==1.4.0
+RUN pip install torchani==1.2
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/docker/torchani/requirements.txt
+++ b/docker/torchani/requirements.txt
@@ -1,4 +1,4 @@
 click
 numpy
-torchvision_nightly
-ase
+torchvision==0.5.0
+ase==3.19.0

--- a/docker/torchani/src/description.json
+++ b/docker/torchani/src/description.json
@@ -1,6 +1,6 @@
 {
   "name": "TorchANI",
-  "version": "0.6",
+  "version": "1.2",
   "input": {
       "format": "cjson",
       "parameters": {


### PR DESCRIPTION
The docker build was broken because "torchvision_nightly" no longer
exists on pypi.

Rather than downloading all of the latest libraries for torchani, lock
in several of the libraries' versions so we can build a consistent
image. This also enables us to keep the torchani version in the
description.json file up-to-date.

I gave this image a try in the notebook and it seemed to work.