### PR TITLE
Mount images plugin in dev mode

### DIFF
--- a/docker/dev/docker-compose.mongochemserver.yml
+++ b/docker/dev/docker-compose.mongochemserver.yml
@@ -3,6 +3,7 @@ services:
   girder:
     volumes:
       - $MONGOCHEMSERVER/girder/app/app:/mongochemserver/girder/app/app
-      - $MONGOCHEMSERVER/girder/notebooks/notebooks:/mongochemserver/girder/notebooks/notebooks
-      - $MONGOCHEMSERVER/girder/molecules/molecules:/mongochemserver/girder/molecules/molecules
+      - $MONGOCHEMSERVER/girder/images/images:/mongochemserver/girder/images/images
       - $MONGOCHEMSERVER/girder/queues/queues:/mongochemserver/girder/queues/queues
+      - $MONGOCHEMSERVER/girder/molecules/molecules:/mongochemserver/girder/molecules/molecules
+      - $MONGOCHEMSERVER/girder/notebooks/notebooks:/mongochemserver/girder/notebooks/notebooks


### PR DESCRIPTION
This is to allow devs to modify the images plugin, and it updates immediately in the server.

Depends on: OpenChemistry/mongochemserver#183