### PR TITLE
Automatically register images in dev environment

### DIFF
--- a/ansible/roles/girder/tasks/dev.yml
+++ b/ansible/roles/girder/tasks/dev.yml
@@ -141,3 +141,16 @@
   until: result.json.status == 'running'
   retries: 10
   delay: 1
+
+- name: Register images on the cluster
+  girder:
+    host: "{{girder_host}}"
+    port: "{{girder_port}}"
+    scheme: "{{girder_scheme}}"
+    apiRoot: "{{girder_api_root}}"
+    token: "{{ me.token }}"
+    post:
+      path: "images/register"
+      json: {
+        "clusterId": "{{cluster._id}}"
+      }


### PR DESCRIPTION
This starts a taskflow to automatically register images on the
cluster once the cluster has started.